### PR TITLE
Add year-aware SpeedyTabs and public wrappers

### DIFF
--- a/customUI14.xml
+++ b/customUI14.xml
@@ -1,0 +1,20 @@
+<customUI xmlns="http://schemas.microsoft.com/office/2009/07/customui">
+  <ribbon>
+    <tabs>
+      <tab id="tabMegaSuite" label="MegaSuite">
+        <group id="grpScen" label="Scenario">
+          <dropDown id="ddlScenario" label="Active" getSelectedItemID="GetScen" onAction="SetScen">
+            <item id="Base" label="Base"/>
+            <item id="Upside" label="Upside"/>
+            <item id="Downside" label="Downside"/>
+            <item id="Stress" label="Stress"/>
+          </dropDown>
+        </group>
+        <group id="grpSOTP" label="SOTP">
+          <button id="btnBuildAdv" label="Re-build Advanced SOTP" onAction="modSOTP_Advanced.BuildAdvancedSOTP"/>
+          <button id="btnFlag" label="Peer Outlier Scan" onAction="modSOTP_Advanced.FlagOutliers"/>
+        </group>
+      </tab>
+    </tabs>
+  </ribbon>
+</customUI>

--- a/modComps.bas
+++ b/modComps.bas
@@ -1,0 +1,35 @@
+'======================================================================
+'  modComps – Comparable-company & transaction multiples hub
+'======================================================================
+Option Private Module
+Option Explicit
+Option Compare Text
+
+' COMP_SHEET layout:  A=Tkr | B=CCY | C=LTM Rev | D=LTM EBITDA | E=EV
+Private Const COMP_SHEET As String = "_Comps"
+
+Public Function GetPeerStats(ByVal metric As String) As Double()
+    Dim ws As Worksheet: Set ws = Worksheets(COMP_SHEET)
+    Dim rng As Range, vals() As Double, i As Long
+    Dim col As Long: col = Switch(metric = "EV/EBITDA", 5, _
+                                  metric = "EV/Revenue", 5, _
+                                  True, 0)
+    If col = 0 Then Err.Raise vbObjectError + 1301, , "Metric not supported"
+    Set rng = ws.Range(ws.Cells(2, col), ws.Cells(ws.Rows.Count, col).End(xlUp))
+    ReDim vals(1 To rng.Rows.Count)
+    For i = 1 To rng.Rows.Count
+        vals(i) = rng.Cells(i).Value / rng.Offset(0, IIf(metric = "EV/EBITDA", -1, -2)).Cells(i).Value
+    Next i
+    GetPeerStats = vals
+End Function
+
+Public Function PeerPercentile(p() As Double, pct As Double) As Double
+    Dim tmp(): tmp = p
+    Dim i As Long, j As Long, t As Double
+    For i = LBound(tmp) To UBound(tmp) - 1
+        For j = i + 1 To UBound(tmp)
+            If tmp(j) < tmp(i) Then t = tmp(i): tmp(i) = tmp(j): tmp(j) = t
+        Next j
+    Next i
+    PeerPercentile = tmp(Application.WorksheetFunction.RoundUp(UBound(tmp) * pct, 0))
+End Function

--- a/modFMP.bas
+++ b/modFMP.bas
@@ -1,0 +1,42 @@
+'======================================================================
+'  modFMP - Financial Modeling Prep API helpers
+'======================================================================
+Option Private Module
+Option Explicit
+Option Compare Text
+
+Private Const FMP_API_KEY As String = "demo"
+Private Const FMP_URL As String = "https://financialmodelingprep.com/api/v3/"
+
+Private Function HttpGet(url As String) As String
+    Dim req As Object
+    Set req = CreateObject("WinHttp.WinHttpRequest.5.1")
+    req.Open "GET", url, False
+    req.Send
+    If req.Status <> 200 Then Err.Raise vbObjectError + 1501, , "HTTP " & req.Status
+    HttpGet = req.ResponseText
+End Function
+
+Public Function FMP_Quote(symbol As String) As Double
+    Dim j As String
+    j = HttpGet(FMP_URL & "quote/" & symbol & "?apikey=" & FMP_API_KEY)
+    FMP_Quote = ExtractNumber(j, "price")
+End Function
+
+Public Function FMP_WACC(symbol As String) As Double
+    Dim j As String
+    j = HttpGet(FMP_URL & "wacc/" & symbol & "?apikey=" & FMP_API_KEY)
+    FMP_WACC = ExtractNumber(j, "wacc")
+End Function
+
+Private Function ExtractNumber(json As String, key As String) As Double
+    Dim p As Long, e As Long
+    p = InStr(json, '"' & key & '"' & ":")
+    If p = 0 Then Exit Function
+    p = p + Len(key) + 3
+    e = p
+    Do While Mid$(json, e, 1) Like "[0-9.Ee+-]"
+        e = e + 1
+    Loop
+    ExtractNumber = CDbl(Mid$(json, p, e - p))
+End Function

--- a/modFX.bas
+++ b/modFX.bas
@@ -1,0 +1,43 @@
+'======================================================================
+'  modFX  – Central FX store & helpers        GG MegaSuite v5.x add-in
+'======================================================================
+Option Private Module
+Option Explicit
+Option Compare Text
+
+'--------------------  CONFIG  --------------------
+Private Const FX_SHEET        As String = "_FX"
+Private Const FX_LAST_UPDATE  As String = "Last_Update"
+
+'--------------------  PUBLIC API  ---------------
+' Put rates in _FX:  Col A=CCY (ISO-3), Col B=USD spot
+Public Function GetFX(ccy As String, _
+                      Optional silent As Boolean = False) As Double
+    Dim ws As Worksheet: Set ws = Worksheets(FX_SHEET)
+    Dim f As Range: Set f = ws.Columns(1).Find(ccy, LookAt:=xlWhole)
+    If f Is Nothing Then
+        If silent Then Exit Function
+        Err.Raise vbObjectError + 1201, , "FX rate for '" & ccy & "' not found"
+    End If
+    GetFX = ws.Cells(f.Row, 2).Value
+End Function
+
+Public Function ConvertCCY(amt As Double, _
+                           fromCcy As String, _
+                           toCcy As String) As Double
+    If fromCcy = toCcy Then
+        ConvertCCY = amt
+    Else
+        Dim usd As Double
+        usd = amt / GetFX(fromCcy, True)  'to USD
+        ConvertCCY = usd * GetFX(toCcy, True)
+    End If
+End Function
+
+'------------------  ADMIN MACROS  ---------------
+' Paste broker feed CSV into _FX!A:B then call SyncFX
+Public Sub SyncFX()
+    GuardSheetExists FX_SHEET
+    Dim ws As Worksheet: Set ws = Worksheets(FX_SHEET)
+    ws.Range("E1").Value = Now
+End Sub

--- a/modLogger.bas
+++ b/modLogger.bas
@@ -1,0 +1,31 @@
+'======================================================================
+'  modLogger - JSON logging utilities
+'======================================================================
+Option Private Module
+Option Explicit
+Option Compare Text
+
+Private Const LOG_SHEET As String = "_Log"
+
+Public Sub LogWrite(msg As String, Optional level As String = "INFO")
+    Dim ws As Worksheet: Set ws = GetOrCreateSheet(LOG_SHEET, False)
+    Dim r As Long: r = ws.Cells(ws.Rows.Count, 1).End(xlUp).Row + 1
+    ws.Cells(r, 1).Value = Now
+    ws.Cells(r, 2).Value = level
+    ws.Cells(r, 3).Value = msg
+End Sub
+
+Public Sub DumpLogJSON()
+    Dim ws As Worksheet: Set ws = Worksheets(LOG_SHEET)
+    Dim arr As Variant: arr = ws.Range("A2", ws.Cells(ws.Rows.Count, 3).End(xlUp)).Value
+    If IsEmpty(arr) Then Exit Sub
+    Dim json As String: json = "["
+    Dim i As Long
+    For i = 1 To UBound(arr, 1)
+        json = json & "{""ts"":""" & arr(i, 1) & """,""lvl"":""" & arr(i, 2) & """,""msg"":""" & Replace(arr(i, 3), """", """""") & """},"
+    Next i
+    json = Left$(json, Len(json) - 1) & "]"
+    Dim f As Object: Set f = CreateObject("Scripting.FileSystemObject").CreateTextFile(ThisWorkbook.Path & "\log_" & Format(Now, "yyyymmdd_hhnnss") & ".json", True, True)
+    f.Write json
+    f.Close
+End Sub

--- a/modMLDiag.bas
+++ b/modMLDiag.bas
@@ -1,0 +1,24 @@
+'======================================================================
+'  modMLDiag - bridge to mlfinlab diagnostics
+'======================================================================
+Option Private Module
+Option Explicit
+
+Private Const PYTHON_EXE As String = "python"
+Private Const SCRIPT_PATH As String = "C:\\ml_scripts\\ml_diagnostics.py"
+
+Public Function RunMLDiag(inputCSV As String, outputJSON As String) As Boolean
+    Dim cmd As String
+    cmd = PYTHON_EXE & " " & SCRIPT_PATH & " """ & inputCSV & """ """ & outputJSON & """"
+    Shell cmd, vbHide
+    RunMLDiag = (Dir(outputJSON) <> "")
+End Function
+
+Public Function ReadMLDiag(path As String) As String
+    Dim fso As Object, ts As Object
+    Set fso = CreateObject("Scripting.FileSystemObject")
+    If Not fso.FileExists(path) Then Exit Function
+    Set ts = fso.OpenTextFile(path)
+    ReadMLDiag = ts.ReadAll
+    ts.Close
+End Function

--- a/modMegaSuite.bas
+++ b/modMegaSuite.bas
@@ -1,0 +1,291 @@
+'======================================================================
+'  modMegaSuite - GG MegaSuite v5.0 core
+'======================================================================
+Option Private Module
+Option Explicit
+Option Compare Text
+
+'==============================  CONFIG  ==============================================
+Public Const CONFIG_SHEET       As String = "Config"
+Public Const CORPORATE_SHEET    As String = "Corporate"
+Public Const WHOLECO_SHEET      As String = "WholeCo"
+Public Const FX_SHEET           As String = "FX_Table"
+Public Const FX_RANGE_NAME      As String = "FX_Matrix"
+Public Const EV_CELL            As String = "EV_Output"
+Public Const SOTP_PREFIX        As String = "SOTP_"
+Public Const ALLOC_KEY_CELL     As String = "B21"
+
+'==========================  ERROR CODE MAP  ==========================================
+Public Const errSOTP_EVMismatch        As Long = vbObjectError + 1001
+Public Const errSOTP_UnallocatedItems  As Long = vbObjectError + 1002
+Public Const errSOTP_InvalidFX         As Long = vbObjectError + 1003
+Public Const errSOTP_ExcessiveDilution As Long = vbObjectError + 1004
+
+Private Enum eErr
+    errMissingTemplate = 900
+    errMissingMacroList = 901
+    errEmptyMacroList = 902
+    errNullWorksheet = 903
+    errSheetNotFound = 904
+    errSheetProtected = 905
+    errBadTemplate = 906
+    errBadLoaderStructure = 907
+    errInsufficientYears = 908
+    errInvalidYear = 909
+End Enum
+
+'===========================  UTILITY HELPERS  ========================================
+Private Function Cfg(key As String, Optional fallback As Variant = "") As Variant
+    On Error Resume Next
+    Dim rng As Range
+    Set rng = Worksheets(CONFIG_SHEET).Columns(1).Find(What:=key, LookIn:=xlValues, _
+                LookAt:=xlWhole, MatchCase:=False)
+    If Not rng Is Nothing Then
+        Cfg = rng.Offset(0, 1).Value
+    Else
+        Cfg = fallback
+    End If
+End Function
+
+Private Function Nz(val As Variant, Optional fallback As Variant = 0) As Variant
+    If IsError(val) Or IsEmpty(val) Or val = "" Then
+        Nz = fallback
+    Else
+        Nz = val
+    End If
+End Function
+
+Private Function IsSOTPSegment(ws As Worksheet) As Boolean
+    IsSOTPSegment = (Left(ws.Name, Len(SOTP_PREFIX)) = SOTP_PREFIX)
+End Function
+
+'=====================  SEGMENT IDENTIFICATION & TAGGING  =============================
+Public Sub TagSOTPSegments()
+    Dim ws As Worksheet
+    For Each ws In ThisWorkbook.Worksheets
+        If ws.Name Like "[A-Z]{1,3}_[0-9][0-9][0-9][0-9]" Then
+            On Error Resume Next
+            ws.Names.Add Name:="SOTP_Flag", RefersTo:="=TRUE"
+            ws.Range("Alloc_Key").Formula = "=" & CONFIG_SHEET & "!" & ALLOC_KEY_CELL
+            On Error GoTo 0
+        End If
+    Next ws
+End Sub
+
+'=======================  CORPORATE ITEM ALLOCATION  ==================================
+Private Function SumVisibleSheets(fieldName As String) As Double
+    Dim ws As Worksheet, total As Double
+    For Each ws In ThisWorkbook.Worksheets
+        If IsSOTPSegment(ws) And ws.Visible Then total = total + Nz(ws.Range(fieldName).Value)
+    Next ws
+    SumVisibleSheets = total
+End Function
+
+Private Function AllocateCorporateItem(seg As Worksheet, corpField As String, segField As String) As Double
+    Dim totalKey As Double: totalKey = SumVisibleSheets(segField)
+    Dim segVal   As Double: segVal = Nz(seg.Range(segField).Value)
+    Dim corpItem As Double: corpItem = Nz(Worksheets(CORPORATE_SHEET).Range(corpField).Value)
+    If totalKey = 0 Then
+        AllocateCorporateItem = 0
+    Else
+        AllocateCorporateItem = Application.Max(0, corpItem * segVal / totalKey)
+    End If
+End Function
+
+Public Sub AllocateCorporateItems()
+    Dim ws As Worksheet
+    For Each ws In ThisWorkbook.Worksheets
+        If IsSOTPSegment(ws) Then
+            ws.Range("SBC_Alloc").Value  = AllocateCorporateItem(ws, "Total_SBC",      Cfg("Alloc_Key", "Revenue"))
+            ws.Range("NWC_Alloc").Value  = AllocateCorporateItem(ws, "Total_NWC",      "Avg_Receivables")
+            ws.Range("CapEx_Maint").Value = ws.Range("PPE").Value * Nz(Cfg("Depr_Rate", 0.03))
+            ws.Range("CapEx_Growth").Value = AllocateCorporateItem(ws, "Growth_CapEx", "Revenue_Growth")
+        End If
+    Next ws
+End Sub
+
+'===============================  FX CONVERSION  ======================================
+Public Function ConvertToReportingCCY(amount As Double, sourceCCY As String) As Double
+    Dim fxTable As Range
+    Set fxTable = Worksheets(FX_SHEET).Range(FX_RANGE_NAME)
+    Dim rate As Double: rate = Nz(Application.VLookup(sourceCCY, fxTable, 2, False))
+    If rate = 0 Then Err.Raise errSOTP_InvalidFX, , "Missing FX rate for: " & sourceCCY
+    ConvertToReportingCCY = amount * rate
+End Function
+
+'=======================  DILUTION-AWARE SHARE BRIDGE  ================================
+Public Sub CalculateDilutedShares()
+    With Worksheets(WHOLECO_SHEET)
+        Dim bs  As Double: bs  = Nz(.Range("Basic_Shares").Value)
+        Dim opt As Double: opt = Nz(.Range("Outstanding_Options").Value)
+        Dim k   As Double: k   = Nz(.Range("Avg_Strike_Price").Value)
+        Dim px  As Double: px  = Nz(FetchFromBloomberg("LAST_PRICE"))
+
+        Dim proceeds As Double: proceeds    = opt * k
+        Dim repurch  As Double: repurch     = proceeds / px
+        Dim netDil   As Double: netDil      = opt - repurch
+
+        .Range("Diluted_Shares").Value = bs + netDil
+        .Range("Dilution_Pct").Value   = netDil / bs
+    End With
+End Sub
+
+'===========================  SOTP VALUATION BUILD  ===================================
+Public Sub BuildSOTPValuation()
+    Dim seg As Worksheet
+    Dim flows As Variant, rates() As Double, rate As Double, i As Long
+    For Each seg In GetBusinessSegments()
+        flows = Application.Transpose(seg.Range("FCF_Stream").Value)
+        rate = Nz(FMP_WACC(seg.Range("Ticker").Value) / 100, Cfg("WACC", 0.1))
+        ReDim rates(LBound(flows) To UBound(flows))
+        For i = LBound(flows) To UBound(flows)
+            rates(i) = rate
+        Next i
+        seg.Range(EV_CELL).Value = DCF_NPV(flows, rates)
+    Next seg
+End Sub
+
+'============================  SOTP ROLLUP  ==============================
+Public Sub BuildRollups()
+    Dim seg As Worksheet, ws As Worksheet
+    Dim rowIdx As Long
+    Set ws = GetOrCreateSheet("SOTP_Rollup", True)
+    ws.Range("A1:B1").Value = Array("Segment", "EV")
+    rowIdx = 2
+    For Each seg In GetBusinessSegments()
+        ws.Cells(rowIdx, 1).Value = seg.Name
+        ws.Cells(rowIdx, 2).Value = Nz(seg.Range("Segment_EV").Value)
+        rowIdx = rowIdx + 1
+    Next seg
+    ws.Cells(rowIdx, 1).Value = "Total"
+    ws.Cells(rowIdx, 2).Formula = "=SUM(B2:B" & rowIdx - 1 & ")"
+    ws.Columns.AutoFit
+End Sub
+
+'==========================  RECONCILIATION & AUDIT  ==================================
+Public Sub VerifySOTPReconciliation()
+    Const TOLERANCE As Double = 0.0001
+    Dim segEVSum As Double: segEVSum = SumVisibleSheets("Segment_EV")
+    Dim wholecoEV As Double: wholecoEV = Worksheets(WHOLECO_SHEET).Range("EntValue").Value
+
+    If Abs(segEVSum - wholecoEV) > TOLERANCE Then
+        LogError "EV MISMATCH: Δ" & Format$(Abs(segEVSum - wholecoEV), "Currency")
+        Worksheets(WHOLECO_SHEET).Range("EntValue").Interior.Color = vbRed
+        Err.Raise errSOTP_EVMismatch, , "SOTP EV mismatch vs WholeCo"
+    End If
+End Sub
+
+Public Sub VerifyNWCTieOut()
+    Dim segNWC As Double: segNWC = SumVisibleSheets("NWC_Alloc")
+    Dim corpNWC As Double: corpNWC = Nz(Worksheets(CORPORATE_SHEET).Range("Total_NWC").Value)
+    Dim wholecoNWC As Double: wholecoNWC = Worksheets(WHOLECO_SHEET).Range("Total_NWC").Value
+    If Abs(segNWC + corpNWC - wholecoNWC) > 0.0001 Then
+        LogWrite "NWC mismatch", "ERROR"
+        Err.Raise errSOTP_UnallocatedItems, , "NWC tie-out failed"
+    End If
+End Sub
+'=========================  PRIMARY SUITE INVOKER  ====================================
+Public Sub RunMegaSuite()
+    Dim t0 As Double
+    t0 = HiResTimerStart()
+    LogWrite "MegaSuite start"
+    If Cfg("SOTP_ENABLED", False) Then
+        TagSOTPSegments
+        AllocateCorporateItems
+        BuildSOTPValuation
+        BuildRollups
+        CalculateDilutedShares
+        VerifySOTPReconciliation
+        VerifyNWCTieOut
+        RunMLDiag ThisWorkbook.Path & "\sotp.csv", ThisWorkbook.Path & "\ml_out.json"
+    End If
+    LogWrite "MegaSuite runtime: " & Format$(HiResTimerEnd(t0), "0.00") & "s"
+    DumpLogJSON
+End Sub
+Private Sub LogError(msg As String)
+    LogWrite msg, "ERROR"
+End Sub
+
+Private Sub LogWarning(msg As String)
+    LogWrite msg, "WARN"
+End Sub
+
+Private Sub FlagVariance(label As String, delta As Double)
+    MsgBox "Variance flagged in " & label & ": Δ" & Format$(delta, "0.00"), vbExclamation
+End Sub
+
+'===========================  EXTERNAL DATA STUBS  ====================================
+Private Function FetchFromBloomberg(fieldCode As String) As Double
+    FetchFromBloomberg = Nz(Worksheets("Bloomberg_PriceCache").Range("Last_Price").Value, 0)
+End Function
+
+'==========================  HIGH-RES TIMING  ============================
+#If VBA7 Then
+    #If Win64 Then
+        Private Declare PtrSafe Function QueryPerformanceCounter Lib "kernel32" (ByRef lp As LongLong) As Long
+        Private Declare PtrSafe Function QueryPerformanceFrequency Lib "kernel32" (ByRef lp As LongLong) As Long
+    #Else
+        Private Declare PtrSafe Function QueryPerformanceCounter Lib "kernel32" (ByRef lp As Currency) As Long
+        Private Declare PtrSafe Function QueryPerformanceFrequency Lib "kernel32" (ByRef lp As Currency) As Long
+    #End If
+#Else
+    Private Declare Function QueryPerformanceCounter Lib "kernel32" (ByRef lp As Currency) As Long
+    Private Declare Function QueryPerformanceFrequency Lib "kernel32" (ByRef lp As Currency) As Long
+#End If
+
+Private Function HiResTimerStart() As Double
+#If Win64 Then
+    Dim t As LongLong, f As LongLong
+    QueryPerformanceCounter t
+    QueryPerformanceFrequency f
+    HiResTimerStart = t / f
+#Else
+    Dim t As Currency, f As Currency
+    QueryPerformanceCounter t
+    QueryPerformanceFrequency f
+    HiResTimerStart = t / f
+#End If
+End Function
+
+Private Function HiResTimerEnd(st As Double) As Double
+#If Win64 Then
+    Dim t As LongLong, f As LongLong
+    QueryPerformanceCounter t
+    QueryPerformanceFrequency f
+    HiResTimerEnd = t / f - st
+#Else
+    Dim t As Currency, f As Currency
+    QueryPerformanceCounter t
+    QueryPerformanceFrequency f
+    HiResTimerEnd = t / f - st
+#End If
+End Function
+
+'===========================  HELPER FUNCTIONS  =======================================
+Public Function GetBusinessSegments() As Collection
+    Dim seg As Worksheet, segs As New Collection
+    For Each seg In ThisWorkbook.Worksheets
+        If Left(seg.Name, Len(SOTP_PREFIX)) = SOTP_PREFIX Then segs.Add seg, seg.Name
+    Next seg
+    Set GetBusinessSegments = segs
+End Function
+
+Public Function SheetExists(nm As String) As Boolean
+    On Error Resume Next
+    SheetExists = Not Worksheets(nm) Is Nothing
+End Function
+
+Public Sub GuardSheetExists(nm As String)
+    If Not SheetExists(nm) Then Err.Raise vbObjectError + errSheetNotFound, , "Sheet '" & nm & "' missing"
+End Sub
+
+Public Function GetOrCreateSheet(nm As String, Optional clearIt As Boolean = False) As Worksheet
+    If SheetExists(nm) Then
+        Set GetOrCreateSheet = Worksheets(nm)
+        If clearIt Then GetOrCreateSheet.Cells.Clear
+    Else
+        Set GetOrCreateSheet = Worksheets.Add(After:=Worksheets(Worksheets.Count))
+        GetOrCreateSheet.Name = nm
+    End If
+End Function
+

--- a/modQuantLib.bas
+++ b/modQuantLib.bas
@@ -1,0 +1,19 @@
+'======================================================================
+'  modQuantLib - QuantLib-style valuation helpers
+'======================================================================
+Option Private Module
+Option Explicit
+Option Compare Text
+
+Public Function DCF_PV(cf As Double, rate As Double, period As Long) As Double
+    DCF_PV = cf / (1 + rate) ^ period
+End Function
+
+Public Function DCF_NPV(flows As Variant, rates As Variant) As Double
+    Dim i As Long, pv As Double
+    If UBound(flows) <> UBound(rates) Then Err.Raise vbObjectError + 2001, , "Rate/flow mismatch"
+    For i = LBound(flows) To UBound(flows)
+        pv = pv + flows(i) / (1 + rates(i)) ^ i
+    Next i
+    DCF_NPV = pv
+End Function

--- a/modSOTP_Advanced.bas
+++ b/modSOTP_Advanced.bas
@@ -1,0 +1,77 @@
+'======================================================================
+'  modSOTP_Advanced – multi-method, FX-aware SOTP engine
+'======================================================================
+Option Private Module
+Option Explicit
+Option Compare Text
+
+' Tag each segment sheet with named range "SEG_CCY" (ISO-3)
+' and populate valuation result cells:
+'   Range("DCF_EV"), Range("Trading_EV"), Range("Transaction_EV")
+
+'------------------  CONSTANTS -------------------
+Private Const DASH_SHEET   As String = "SOTP_Dashboard"
+Private Const SEG_PREFIX   As String = "SOTP_"
+Private Enum eMethod: mDCF = 1: mTrading: mDeal: End Enum
+
+'------------------  ENTRY POINT -----------------
+Public Sub BuildAdvancedSOTP()
+    Dim segs As Collection: Set segs = GetBusinessSegments()
+    Dim ws As Worksheet: Set ws = GetOrCreateSheet(DASH_SHEET, True)
+    
+    ws.Range("A1:F1").Value = Array("Segment", "Method", "Local EV", _
+                                    "CCY", "USD EV", "EV Weight")
+    Dim r As Long: r = 2
+    Dim evTotal As Double, s As Worksheet, usdEV As Double
+    Dim m As eMethod
+    
+    For Each s In segs
+        For m = mDCF To mDeal
+            Dim locEV As Double: locEV = ValByMethod(s, m)
+            If locEV = 0 Then GoTo nxtM
+            usdEV = ConvertCCY(locEV, s.Range("SEG_CCY").Value, "USD")
+            ws.Cells(r, 1).Resize(1, 5).Value = _
+                Array(Replace(s.Name, SEG_PREFIX, ""), _
+                      MethodName(m), locEV, s.Range("SEG_CCY").Value, usdEV)
+            evTotal = evTotal + usdEV
+            r = r + 1
+nxtM:   Next m
+    Next s
+    
+    ws.Range("F2:F" & r - 1).FormulaR1C1 = "=RC[-1]/" & evTotal
+    ws.Columns.AutoFit
+End Sub
+
+Private Function ValByMethod(seg As Worksheet, m As eMethod) As Double
+    Select Case m
+        Case mDCF:        ValByMethod = Nz(seg.Range("DCF_EV").Value)
+        Case mTrading:    ValByMethod = Nz(seg.Range("Trading_EV").Value)
+        Case mDeal:       ValByMethod = Nz(seg.Range("Transaction_EV").Value)
+    End Select
+End Function
+
+Private Function MethodName(m As eMethod) As String
+    MethodName = Choose(m, "", "DCF", "Trading Comp", "Deal Comp")
+End Function
+
+'------------------  PEER FLAGGING ----------------
+Public Sub FlagOutliers()
+    Dim segs As Collection: Set segs = GetBusinessSegments()
+    Dim p() As Double: p = GetPeerStats("EV/EBITDA")
+    Dim hi As Double: hi = PeerPercentile(p, 0.75)
+    
+    Dim s As Worksheet
+    For Each s In segs
+        Dim ev As Double, ebitda As Double
+        ev = s.Range("Trading_EV").Value
+        ebitda = s.Range("EBITDA").Value
+        If ebitda <= 0 Then GoTo nxt
+        If (ev / ebitda) > hi Then
+            s.Range("Trading_EV").Interior.ColorIndex = 22
+        End If
+nxt: Next s
+End Sub
+
+'------------------  UTIL ------------------------
+Private Function Nz(v) As Double: If IsNumeric(v) Then Nz = v
+End Function

--- a/modSectorTemplates.bas
+++ b/modSectorTemplates.bas
@@ -1,0 +1,33 @@
+'======================================================================
+'  modSectorTemplates – sector-specific template cloning
+'======================================================================
+Option Private Module
+Option Explicit
+Option Compare Text
+
+' Template names must follow pattern  TPL_<Sector>
+' Asset sheet name requested as   <Ticker>_<YYYY>_<Sector>
+
+Private Const TPL_PREFIX     As String = "TPL_"
+
+Public Sub AutoAssetDiscovery()
+    Dim rgx As Object: Set rgx = CreateObject("VBScript.RegExp")
+    rgx.Pattern = "^[A-Z]{1,3}_\d{4}_(\w+)$"
+    Dim w As Worksheet, m, tpl
+
+    For Each w In Worksheets
+        If rgx.Test(w.Name) Then
+            Set m = rgx.Execute(w.Name)
+            tpl = TPL_PREFIX & UCase$(m(0).SubMatches(0))
+            If SheetExists(tpl) Then
+                CloneIfEmpty w, tpl
+            End If
+        End If
+    Next w
+End Sub
+
+Private Sub CloneIfEmpty(tgt As Worksheet, tpl As String)
+    If Application.WorksheetFunction.CountA(tgt.Cells) > 0 Then Exit Sub
+    Worksheets(tpl).Copy Before:=tgt
+    tgt.Delete
+End Sub

--- a/modSpeedyTabs.bas
+++ b/modSpeedyTabs.bas
@@ -1,0 +1,99 @@
+'======================================================================
+'  modSpeedyTabs – bucket tab builder and rollup summarizer (2025)
+'======================================================================
+Option Private Module
+Option Explicit
+
+Private Const BUCKET_COL As Long = 5      'Column E
+Private Const HEADER_ROW As Long = 1
+Private Const BUCKET_YEAR As Long = 2025
+Private BucketSheets As Variant
+
+'---------------------------
+' Build or refresh A/U/D tabs from active sheet
+'---------------------------
+Public Sub GGSpeedyTabs()
+    Dim srcWS As Worksheet
+    Dim lastRow As Long
+    Dim r As Long, bucket As String
+    Dim ws As Worksheet
+    Dim destWS As Worksheet
+    Dim destRow As Long
+    BucketSheets = Array("A_" & BUCKET_YEAR, "U_" & BUCKET_YEAR, "D_" & BUCKET_YEAR)
+
+    Set srcWS = ActiveSheet
+    lastRow = srcWS.Cells(srcWS.Rows.Count, BUCKET_COL).End(xlUp).Row
+
+    Application.ScreenUpdating = False
+    Application.DisplayAlerts = False
+
+    Dim b As Variant
+    For Each b In BucketSheets
+        KillSheet b
+        Set ws = Worksheets.Add(After:=srcWS)
+        ws.Name = b
+        srcWS.Rows(HEADER_ROW).Copy ws.Rows(HEADER_ROW)
+    Next b
+
+    For r = HEADER_ROW + 1 To lastRow
+        bucket = UCase$(Trim$(srcWS.Cells(r, BUCKET_COL).Value))
+        If bucket <> "" Then
+            For Each b In BucketSheets
+                If bucket & "_" & BUCKET_YEAR = b Then
+                    Set destWS = Worksheets(b)
+                    destRow = destWS.Cells(destWS.Rows.Count, 1).End(xlUp).Row + 1
+                    srcWS.Rows(r).Copy destWS.Rows(destRow)
+                    destWS.Cells(destRow, BUCKET_COL).ClearContents
+                End If
+            Next b
+        End If
+    Next r
+
+    For Each b In BucketSheets
+        Worksheets(b).Columns.AutoFit
+    Next b
+
+    Application.DisplayAlerts = True
+    Application.ScreenUpdating = True
+    MsgBox "GGSpeedyTabs completed", vbInformation
+End Sub
+
+'---------------------------
+' Summarize each bucket into Rollup_YYYY
+'---------------------------
+Public Sub BuildSpeedyRollup()
+    BucketSheets = Array("A_" & BUCKET_YEAR, "U_" & BUCKET_YEAR, "D_" & BUCKET_YEAR)
+    Dim roll As Worksheet, ws As Worksheet
+    Dim col As Long, lastRow As Long
+    Dim destRow As Long, b As Variant
+
+    KillSheet "Rollup_" & BUCKET_YEAR
+    Set roll = Worksheets.Add(After:=Worksheets(Worksheets.Count))
+    roll.Name = "Rollup_" & BUCKET_YEAR
+
+    Worksheets(BucketSheets(0)).Rows(HEADER_ROW).Copy roll.Rows(HEADER_ROW)
+    destRow = HEADER_ROW + 1
+
+    For Each b In BucketSheets
+        Set ws = Worksheets(b)
+        roll.Cells(destRow, 1).Value = b
+        For col = 1 To ws.Cells(HEADER_ROW, ws.Columns.Count).End(xlToLeft).Column
+            If col <> BUCKET_COL Then
+                lastRow = ws.Cells(ws.Rows.Count, col).End(xlUp).Row
+                roll.Cells(destRow, col).Value = Application.Sum(ws.Range(ws.Cells(HEADER_ROW + 1, col), ws.Cells(lastRow, col)))
+            End If
+        Next col
+        destRow = destRow + 1
+    Next b
+
+    roll.Columns.AutoFit
+End Sub
+
+'---------------------------
+' Delete sheet if it exists
+'---------------------------
+Private Sub KillSheet(nm As String)
+    On Error Resume Next
+    Worksheets(nm).Delete
+    On Error GoTo 0
+End Sub

--- a/modUI.bas
+++ b/modUI.bas
@@ -1,0 +1,16 @@
+'======================================================================
+'  modUI - simple wrappers for Macro dialog
+'======================================================================
+Option Explicit
+
+Public Sub RunMegaSuite_UI()
+    modMegaSuite.RunMegaSuite
+End Sub
+
+Public Sub GGSpeedyTabs_UI()
+    modSpeedyTabs.GGSpeedyTabs
+End Sub
+
+Public Sub BuildSpeedyRollup_UI()
+    modSpeedyTabs.BuildSpeedyRollup
+End Sub


### PR DESCRIPTION
## Summary
- modify `GGSpeedyTabs` to create bucket sheets for the configured year and clear bucket column after copying
- update rollup generator to aggregate from year-labelled bucket sheets
- add small `modUI` module exposing public wrapper macros

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868772a8904832cae012aa58ac96cb9